### PR TITLE
#23/route editor page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,7 @@ const pandaStyle = css({
 export default function HomePage() {
   return (
     <>
-      <Link href='/login'>go to login</Link>
+      <Link href='/login'>go to login</Link> | <Link href='/editor'>go to editor page</Link>
       <div className={pandaStyle}>PANDA CSS WORKING AS SERVER COMPONENT</div>
       <BlockNote />
       <TestButton />

--- a/src/pages/editor.tsx
+++ b/src/pages/editor.tsx
@@ -16,8 +16,8 @@ export default function Editor() {
   const [title, setTitle] = useState("");
 
   const handleTitle: ChangeEventHandler<HTMLInputElement> = (e) => {
-    const value = e.currentTarget.value;
-    setTitle(value);
+    const newTitle = e.currentTarget.value;
+    setTitle(newTitle);
   };
 
   return (

--- a/src/pages/editor.tsx
+++ b/src/pages/editor.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { ChangeEventHandler, useState } from "react";
+
+const BlockNote = dynamic(
+  async () => {
+    const { BlockNote } = await import("src/components/BlockNote");
+    return { default: BlockNote };
+  },
+  { ssr: false },
+);
+
+export default function Editor() {
+  const [title, setTitle] = useState("");
+
+  const handleChangeTitle: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const value = e.currentTarget.value;
+    setTitle(value);
+  };
+
+  return (
+    <>
+      <h2>에디터 페이지</h2>
+      <div>
+        <Link href='/'>home</Link>
+      </div>
+      <label>
+        <span>Title: </span>
+        <input value={title} onChange={handleChangeTitle}></input>
+      </label>
+      <BlockNote />
+    </>
+  );
+}

--- a/src/pages/editor.tsx
+++ b/src/pages/editor.tsx
@@ -15,7 +15,7 @@ const BlockNote = dynamic(
 export default function Editor() {
   const [title, setTitle] = useState("");
 
-  const handleChangeTitle: ChangeEventHandler<HTMLInputElement> = (e) => {
+  const handleTitle: ChangeEventHandler<HTMLInputElement> = (e) => {
     const value = e.currentTarget.value;
     setTitle(value);
   };
@@ -28,7 +28,7 @@ export default function Editor() {
       </div>
       <label>
         <span>Title: </span>
-        <input value={title} onChange={handleChangeTitle}></input>
+        <input value={title} onChange={handleTitle}></input>
       </label>
       <BlockNote />
     </>


### PR DESCRIPTION
## 리뷰 포인트

- `/editor` 페이지 생성 & 라우팅할 수 있는 링크 추가
- `/editor` 페이지 내에 타이틀을 입력할 수 있는 input 추가
- `/editor` 페이지 내에 BlockNote 추가

## 스크린 샷
![image](https://github.com/ganada-labs/nlog-FE/assets/40891497/c2576e82-3791-4c04-a6e3-1431e6785c22)
go to editor page 링크가 추가됨

![image](https://github.com/ganada-labs/nlog-FE/assets/40891497/d2ec317f-4125-4bd2-adc6-7a460e3addfa)
에디터 페이지가 추가되었음

![image](https://github.com/ganada-labs/nlog-FE/assets/40891497/0aace0bb-ec90-43b5-a96e-74574c23936a)
입력 가능
