### PR TITLE
refactor/ post 랜더링 라우트 경로 수정

### DIFF
--- a/src/pages/editor.tsx
+++ b/src/pages/editor.tsx
@@ -35,7 +35,7 @@ export default function Editor() {
       title,
     });
 
-    router.push(`/${data.id}`);
+    router.push(`/post/${data.id}`);
   };
 
   return (


### PR DESCRIPTION
## 리뷰 포인트

- 기존엔 에디터로 글을 작성하고 publish하면 /id 로 이동했지만 /post/id로 이동하도록 수정함
## 스크린 샷

