### PR TITLE
fix/ access token이 없는 상태에서 포스트를 패치하는 문제 해결

### DIFF
--- a/src/pages/posts/[id].tsx
+++ b/src/pages/posts/[id].tsx
@@ -90,7 +90,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const { id } = context.query;
   const { data } = await fetchPost(id as string);
   const { isAuthor, post } = data;
-
+  console.log(isAuthor);
   return {
     props: {
       isAuthor,

--- a/src/pages/users/[email].tsx
+++ b/src/pages/users/[email].tsx
@@ -1,4 +1,10 @@
-import { fetchPostList, fetchUserById, type PostResponse, type User } from "src/requests";
+import {
+  fetchPostList,
+  fetchUser,
+  fetchUserById,
+  type PostResponse,
+  type User,
+} from "src/requests";
 
 import { type GetServerSideProps } from "next";
 import Link from "next/link";
@@ -30,6 +36,7 @@ export default function Post(props: Props) {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { email } = context.query;
+  await fetchUser(); // access token 갱신용
   const { data: user } = await fetchUserById(email as string);
   const { data: posts } = await fetchPostList(user.email);
   return {

--- a/src/requests/user/index.ts
+++ b/src/requests/user/index.ts
@@ -5,6 +5,10 @@ export type User = {
   email: string;
 };
 
+export async function fetchUser() {
+  return await nlogAPI.get("/user");
+}
+
 export async function fetchUserById(id: string) {
   return await nlogAPI.get(`/user/${id}`);
 }


### PR DESCRIPTION
## 리뷰 포인트

- 포스트 페이지에선 access token이 없어도 포스트를 반환해야하기 때문에 401에러를 발생시키지 않음. 따라서 access token이 없는 상태에서 access token refresh가 발생하지 않음. 
- 이를 해결하기 위해 일단 user 정보를 한번 패치하도록 만듦.
## 스크린 샷

