### PR TITLE
update/ isAuthor를 서버에서 패치하는 것이 아닌 클라이언트에서 랜더링 시에 패치하도록 수정

### DIFF
--- a/src/requests/post/index.ts
+++ b/src/requests/post/index.ts
@@ -22,6 +22,10 @@ export async function createPost(post: Post) {
   return await nlogAPI.post("/post", post);
 }
 
+export async function fetchIsAuthor(id: string) {
+  return await nlogAPI.get(`/post/${id}?isAuthor=true`);
+}
+
 export async function fetchPost(id: string) {
   return await nlogAPI.get(`/post/${id}`);
 }


### PR DESCRIPTION
## 리뷰 포인트

트러블 슈팅이 있었습니다.

![image](https://github.com/ganada-labs/nlog-FE/assets/40891497/80becceb-4187-4753-ae52-176793190ebb)

위와 같은 timeout 에러가 떴고, 문제를 추적하다보니, 서버에서 auth/refresh 요청이 반복적으로 일어나는 것을 확인했습니다.

이는 401에러를 만났기 때문입니다. (401이 뜨면 auth/refresh를 보내도록 하고 있음)

서버의 구조적 문제도 맞습니다. 나중에 auth/refresh는 절대 401을 안보내도록 수정할 예정입니다.

다만 이 경우 401이 뜬 것은 서버에서 refresh_token 쿠키를 설정해 보내지 않았기 때문입니다. getServerSideProps에서 포스트 정보를 요청하면서 cookie를 전송하지 않았고, 쿠키가 없어 401이 뜬 것입니다.

원론적으로 생각해보면 서버에선 쿠키를 갖고 있지 않습니다. (브라우저가 갖고 있죠?)

따라서 서버 사이드에서 쿠키를 담아 전송하는 것은 불가능하고, 클라이언트에서 렌더링이 된 이후, 이 글이 유저가 작성한 글인지 여부만 받아오기로 했습니다.

따라서 useEffect를 활용해 최초 랜더링 이후 isAuthor를 패치합니다.

## 스크린 샷

