### PR TITLE
fix/ posts/undefined로 이동하는 버그 수정

### DIFF
--- a/src/pages/editor/[id].tsx
+++ b/src/pages/editor/[id].tsx
@@ -46,12 +46,12 @@ export default function Editor(props: Props) {
   };
 
   const handleUpdate: MouseEventHandler<HTMLButtonElement> = async () => {
-    const { data } = await updatePost(post.id, {
+    await updatePost(post.id, {
       contents,
       title,
     });
 
-    router.push(`/posts/${data.id}`);
+    router.push(`/posts/${post.id}`);
   };
 
   return (


### PR DESCRIPTION
에디터페이지에서 문서를 수정하고 update하면 /posts/undefind로 이동하는
버그가 있음

post.id를 사용해야하는데, data.id로 link하고 있었슴.

따라서 post.id를 사용하도록 수정해서 해결!

## 리뷰 포인트


## 스크린 샷

